### PR TITLE
Don't abort the interpreter when io_uring is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ Requirements
 ============
 This is only working with a linux kernel and works best with a Kernel 6 or newer.
 
+Runtime availability
+=====================
+Not every machine this gem gets embedded on can actually use io_uring at
+runtime -- an old kernel (ENOSYS), or a seccomp profile/sysctl that blocks
+it (EPERM/EACCES), are normal, expected outcomes, not bugs. Rather than
+aborting the whole interpreter on startup when that happens, this gem
+probes io_uring once during `mrb_open()` and exposes the result as a plain
+top-level `URING_AVAILABLE` boolean.
+
+When `URING_AVAILABLE` is `false`, `IO::Uring` is not defined at all --
+check `URING_AVAILABLE`, not `defined?(IO::Uring)`, wherever your code
+(including other gems) needs to know whether it can use this gem.
+
+```ruby
+if URING_AVAILABLE
+  uring = IO::Uring.new
+  # ...
+else
+  # fall back to something else, or skip io_uring-dependent features
+end
+```
+
+The same applies if the *build* host itself can't build liburing (missing
+Linux kernel headers, no C++17-capable compiler, cross-compiling for a
+target without a matching sysroot, etc.) -- mrbgem.rake attempts liburing's
+own `./configure && make`, and if that fails, the rest of your mruby build
+still succeeds; you just end up with `URING_AVAILABLE` hardcoded to `false`
+in that build, same as above.
+
 Installation
 ============
 The gem is called mruby-io-uring for adding it to your project, here is an example.

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,24 +1,43 @@
-require_relative 'mrblib/version.rb'
+require_relative 'version.rb'
 
 MRuby::Gem::Specification.new('mruby-io-uring') do |spec|
   spec.license = 'Apache-2.0'
   spec.author  = 'Hendrik Beskow'
   spec.summary = 'io_uring for mruby'
-  spec.version = IO::Uring::VERSION
+  spec.version = IO_URING_VERSION
   spec.add_dependency 'mruby-io'
   spec.add_dependency 'mruby-socket'
   spec.add_dependency 'mruby-errno'
-  unless File.file? "#{spec.build_dir}/build/lib/liburing.a"
+
+  liburing_lib = "#{spec.build_dir}/build/lib/liburing.a"
+  liburing_buildable = File.file?(liburing_lib)
+  unless liburing_buildable
     command = "mkdir -p #{spec.build_dir}/build && cd #{spec.dir}/deps/liburing/ && ./configure "
     if spec.cc.flags.any? { |entry| entry.is_a?(String) && entry.start_with?("-fsanitize=") }
       command << "--enable-sanitizer"
     end
     command << " --prefix=\"#{spec.build_dir}/build\" --cc=\"#{spec.cc.command}\" --cxx=\"#{spec.cxx.command}\" && make -j$(nproc) && make install && make clean"
-    sh command
+    # Block form: like liburing's own configure script, actually attempt the
+    # build and see what it returns, rather than assuming success. Passing a
+    # block makes Rake's sh NOT raise on a nonzero exit -- a build host that
+    # can't build liburing (missing kernel headers, no C++17 compiler, ...)
+    # is handled below by building without io_uring support instead of
+    # aborting the entire mruby build over one gem.
+    sh(command) { |ok, _status| liburing_buildable = ok }
   end
-  ENV['PKG_CONFIG_PATH'] = "#{spec.build_dir}/build/lib/pkgconfig:" + (ENV['PKG_CONFIG_PATH'] || '')
-  spec.cc.flags += [`pkg-config --cflags liburing`.strip]
-  spec.cxx.flags += [`pkg-config --cflags liburing`.strip]
-  spec.linker.flags_after_libraries += ["#{spec.build_dir}/build/lib/liburing.a"]
+
+  if liburing_buildable
+    # Tells src/mrb_io_uring.h and src/mrb_io_uring.cpp they can actually
+    # #include liburing.h and compile the real gem_init -- see the comment
+    # at the top of mrb_io_uring.h for how that's used.
+    spec.cc.defines  << 'MRB_IO_URING_BUILDABLE'
+    spec.cxx.defines << 'MRB_IO_URING_BUILDABLE'
+    ENV['PKG_CONFIG_PATH'] = "#{spec.build_dir}/build/lib/pkgconfig:" + (ENV['PKG_CONFIG_PATH'] || '')
+    spec.cc.flags += [`pkg-config --cflags liburing`.strip]
+    spec.cxx.flags += [`pkg-config --cflags liburing`.strip]
+    spec.linker.flags_after_libraries += [liburing_lib]
+  else
+    warn "mruby-io-uring: could not build liburing on this host (see the build output above) -- building without io_uring support; URING_AVAILABLE will always be false."
+  end
   spec.cxx.flags << '-std=c++17'
 end

--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -1,3 +1,17 @@
+# URING_AVAILABLE is set by mrb_mruby_io_uring_gem_init (src/mrb_io_uring.cpp,
+# see the long comment at its top) before mrblib loads, based on whether this
+# machine can actually create an io_uring instance right now. When false,
+# native gem_init already skipped defining any method on IO::Uring, and this
+# file skips too, so nothing here ever adds a method either.
+#
+# Check URING_AVAILABLE, not `defined?(IO::Uring)`, wherever this needs
+# checking (including from other gems, e.g. webmachine-mruby's adapter) --
+# it's the constant this gem defines and guarantees for exactly this
+# purpose. See mrb_io_uring.cpp's comment at the top of gem_init for why:
+# every file that touches IO::Uring, including this one, has to guard its
+# whole body the same way for `defined?(IO::Uring)` to be trustworthy too.
+if URING_AVAILABLE
+
 class IO::Uring
   class << self
     def default_io_uring
@@ -127,3 +141,5 @@ class IO::Uring
     include ServerSocketMethods
   end
 end
+
+end # URING_AVAILABLE

--- a/mrblib/operation.rb
+++ b/mrblib/operation.rb
@@ -1,3 +1,11 @@
+# See the top of io.rb (and mrb_io_uring.cpp) for what URING_AVAILABLE is
+# and why this guard exists: without it, `class IO; class Uring; ...` below
+# would add an Operation class -- and, unlike io.rb's `class IO::Uring`
+# form, this one doesn't even require IO::Uring to already exist first, so
+# it would define IO::Uring::Operation with real, working attr_readers
+# regardless of native availability.
+if URING_AVAILABLE
+
 class IO
   class Uring
     class Operation
@@ -49,3 +57,5 @@ class IO
     end
   end
 end
+
+end # URING_AVAILABLE

--- a/mrblib/version.rb
+++ b/mrblib/version.rb
@@ -1,5 +1,0 @@
-class IO
-    class Uring
-        VERSION = '0.10.0'
-    end
-end

--- a/src/mrb_io_uring.cpp
+++ b/src/mrb_io_uring.cpp
@@ -1,5 +1,7 @@
 #include "mrb_io_uring.h"
 
+#ifdef MRB_IO_URING_BUILDABLE
+
 static mrb_value
 mrb_io_uring_queue_init_params(mrb_state *mrb, mrb_value self)
 {
@@ -1725,10 +1727,56 @@ initialize_can_use_buffers_once()
   io_uring_queue_exit(&ring);
 }
 
+#endif // MRB_IO_URING_BUILDABLE
+
 MRB_BEGIN_DECL
+
+#ifdef MRB_IO_URING_BUILDABLE
+
 void
 mrb_mruby_io_uring_gem_init(mrb_state* mrb)
 {
+  /*
+   * Checked first, before anything else: mrb_open() runs every gem's
+   * gem_init with no Ruby-level rescue in place yet, so mrb_sys_fail()
+   * here (as this used to do, further down, after IO::Uring already had
+   * a class and #initialize/#submit defined) would abort the whole
+   * interpreter rather than give the embedding program a chance to react.
+   * A kernel too old for io_uring (ENOSYS), or a seccomp profile/sysctl
+   * that blocks it (EPERM/EACCES), is a normal, expected outcome on some
+   * machines -- not a bug.
+   *
+   * URING_AVAILABLE is set on Object either way, before anything else, so
+   * both this function and mrblib/io.rb + mrblib/operation.rb (see their
+   * own top) can gate on the exact same signal: when false, this function
+   * returns immediately without defining any method or constant on
+   * IO::Uring (including VERSION, defined natively below rather than in
+   * mrblib specifically so it can't end up as an exception to this), and
+   * those two mrblib files skip their entire body too, so nothing under
+   * IO::Uring ever gets defined at all.
+   *
+   * `defined?(IO::Uring)` is consequently a reliable "is this usable"
+   * signal too, but URING_AVAILABLE remains the constant this gem defines
+   * and documents for that purpose: every file that touches IO::Uring has
+   * to individually remember to guard itself for `defined?(IO::Uring)` to
+   * hold, and one forgetting (e.g. a bare version-string constant, easy
+   * to assume is harmless) would break it silently, whereas
+   * URING_AVAILABLE can't be wrong by omission the same way. Note this
+   * has nothing to do with presym: presym'ing a name via MRB_SYM() (as
+   * `Uring` is right here) interns the symbol table entry but does not by
+   * itself cause mruby to instantiate anything for it.
+   *
+   * io_uring_get_probe() already does exactly the availability check this
+   * needs internally (io_uring_queue_init() on a scratch ring, torn down
+   * again immediately) and returns NULL on failure; the result is reused
+   * below instead of probing twice.
+   */
+  struct io_uring_probe *probe = io_uring_get_probe();
+  mrb_define_const_id(mrb, mrb->object_class, MRB_SYM(URING_AVAILABLE), mrb_bool_value(probe != NULL));
+  if (!probe) {
+    return;
+  }
+
   pthread_mutex_lock(&mutex);
   if (init_once_done == FALSE) {
     init_once_done = TRUE;
@@ -1747,14 +1795,13 @@ mrb_mruby_io_uring_gem_init(mrb_state* mrb)
 
   io_uring_class = mrb_define_class_under_id(mrb, mrb_class_get_id(mrb, MRB_SYM(IO)), MRB_SYM(Uring), mrb->object_class);
   MRB_SET_INSTANCE_TT(io_uring_class, MRB_TT_CDATA);
+  // Kept in sync with IO_URING_VERSION in version.rb (gem root) by hand;
+  // see that file for why it isn't shared directly.
+  mrb_define_const_id(mrb, io_uring_class, MRB_SYM(VERSION), mrb_str_new_cstr(mrb, "0.10.0"));
   mrb_define_method_id(mrb, io_uring_class, MRB_SYM(initialize),              mrb_io_uring_queue_init_params,       MRB_ARGS_OPT(2));
   mrb_define_method_id(mrb, io_uring_class, MRB_SYM(submit),                  mrb_io_uring_submit,                  MRB_ARGS_NONE());
   mrb_value op_types = mrb_ary_new(mrb);
 
-  struct io_uring_probe *probe = io_uring_get_probe();
-  if (!probe) {
-    mrb_sys_fail(mrb, "io_uring_get_probe");
-  }
   if (io_uring_opcode_supported(probe, IORING_OP_SOCKET)) {
     mrb_define_method_id(mrb, io_uring_class, MRB_SYM(prep_socket), mrb_io_uring_prep_socket, MRB_ARGS_ARG(2, 3)|MRB_ARGS_BLOCK());
     mrb_define_method_id(mrb, io_uring_class, MRB_SYM(build_socket), mrb_io_uring_build_socket, MRB_ARGS_ARG(1, 2)|MRB_ARGS_BLOCK());
@@ -1976,6 +2023,26 @@ mrb_mruby_io_uring_gem_init(mrb_state* mrb)
   MRB_SET_INSTANCE_TT(io_uring_socket_class, MRB_TT_CDATA);
   mrb_define_module_function_id(mrb, io_uring_socket_class, MRB_SYM(for_fd), mrb_io_uring_socket_for_fd, MRB_ARGS_REQ(2));
 }
+
+#else // MRB_IO_URING_BUILDABLE
+
+void
+mrb_mruby_io_uring_gem_init(mrb_state* mrb)
+{
+  /*
+   * mrbgem.rake could not build liburing on this host -- missing kernel
+   * headers, no C++17-capable compiler, or some other prerequisite
+   * ./configure && make needs was not met (see the build log for what
+   * actually failed). URING_AVAILABLE is still defined, just always
+   * false, so mrblib/io.rb and mrblib/operation.rb -- which key off this
+   * exact same constant -- behave exactly as they do when a working
+   * liburing probes unavailable at runtime instead: IO::Uring is not
+   * defined at all, and nothing here crashes.
+   */
+  mrb_define_const_id(mrb, mrb->object_class, MRB_SYM(URING_AVAILABLE), mrb_false_value());
+}
+
+#endif // MRB_IO_URING_BUILDABLE
 
 void mrb_mruby_io_uring_gem_final(mrb_state* mrb) {}
 MRB_END_DECL

--- a/src/mrb_io_uring.h
+++ b/src/mrb_io_uring.h
@@ -2,6 +2,21 @@
 #define _LARGEFILE64_SOURCE
 #define _GNU_SOURCE
 
+/*
+ * mrbgem.rake defines MRB_IO_URING_BUILDABLE only after it has actually
+ * run liburing's own ./configure && make on this build host and gotten a
+ * real liburing.a out of it. Everything below that depends on liburing
+ * (or on liburing having built successfully) is guarded on it, so a
+ * build host that can't build liburing -- missing kernel headers, no
+ * C++17 compiler, whatever -- still produces a working mruby binary:
+ * see the #else branch of mrb_mruby_io_uring_gem_init in
+ * mrb_io_uring.cpp for what that binary exposes instead.
+ */
+#include <mruby.h>
+#include <mruby/presym.h>
+
+#ifdef MRB_IO_URING_BUILDABLE
+
 #include <liburing.h>
 #include <pthread.h>
 #include <sys/resource.h>
@@ -20,7 +35,6 @@
 #include <sys/syscall.h>
 #include <netinet/in.h>
 
-#include <mruby.h>
 #include <mruby/data.h>
 #include <mruby/hash.h>
 #include <mruby/variable.h>
@@ -28,7 +42,6 @@
 #include <mruby/ext/io_uring.h>
 #include <mruby/string.h>
 #include <mruby/class.h>
-#include <mruby/presym.h>
 #include <mruby/error.h>
 
 #ifndef NSEC_PER_SEC
@@ -159,3 +172,5 @@ static mrb_bool can_use_buffers = FALSE;
 #ifndef MRB_UNSET_FROZEN_FLAG
 #define MRB_UNSET_FROZEN_FLAG(o) ((o)->frozen = 0)
 #endif
+
+#endif // MRB_IO_URING_BUILDABLE

--- a/version.rb
+++ b/version.rb
@@ -1,0 +1,6 @@
+# Read by mrbgem.rake under host CRuby (via rake) for spec.version. Not
+# compiled into the target mruby binary at all -- IO::Uring::VERSION is
+# defined natively in src/mrb_io_uring.cpp instead, right alongside the
+# rest of the class, so it's automatically covered by the same
+# URING_AVAILABLE gating as everything else there. Bump both together.
+IO_URING_VERSION = '0.10.0'


### PR DESCRIPTION
gem_init used to define IO::Uring's class and #initialize/#submit first, then call io_uring_get_probe() afterwards to gate the opcode-specific prep_*/build_* methods -- but if that probe failed (old kernel, seccomp, container, or any other reason io_uring_setup(2) can't succeed here), it called mrb_sys_fail() at a point in mrb_open() where no Ruby-level rescue exists yet. That aborts the whole interpreter instead of giving the embedding program a chance to react, on what is a normal, expected outcome on some machines rather than a bug.

The probe now runs first, before anything is defined, and its result is exposed as a plain top-level URING_AVAILABLE boolean constant that native gem_init and every mrblib file that touches IO::Uring (io.rb, operation.rb) gate on consistently, so a probe failure means nothing under IO::Uring ever gets a single method or constant defined -- not a crash, and not a partially working class. IO::Uring::VERSION is defined natively in gem_init itself rather than from mrblib, so it's automatically covered by the same gate instead of needing its own. `defined?(IO::Uring)` is consequently a reliable "is this usable" signal too, but URING_AVAILABLE remains the constant this gem defines and documents for that purpose, since every file touching IO::Uring has to individually remember to guard itself for `defined?` to hold, whereas URING_AVAILABLE can't be wrong by omission the same way.

version.rb (gem root, not mrblib) holds the gem's version as a single plain constant, IO_URING_VERSION, read by mrbgem.rake under host CRuby (via rake) for spec.version -- nothing more. It is not compiled into the target mruby binary; keep it in sync with the native VERSION constant by hand when bumping.

Separately, mrbgem.rake no longer assumes liburing's own `./configure && make` succeeds. It actually runs it and checks what came back (mirroring what that configure script itself does for its own feature probes), using Rake's block form of `sh` so a failure doesn't raise and abort the entire mruby build over this one gem. Success gates a new MRB_IO_URING_BUILDABLE compiler define, which src/mrb_io_uring.h and src/mrb_io_uring.cpp use to skip including liburing.h and compiling any liburing-dependent code entirely when the build host can't provide it (missing kernel headers, no C++17 compiler, cross-compiling without a matching sysroot, ...); gem_init falls back to a stub that only ever sets URING_AVAILABLE to false. This is the same contract as the runtime probe, just decided at build time instead: either way, consuming code only ever needs to check the one constant.

README.md documents both cases for consumers of this gem.

Verified end to end, including two fault-injected scenarios (temporary, not part of this commit): forcing io_uring_get_probe() to fail at runtime, and forcing liburing's ./configure to fail at build time. Both correctly result in URING_AVAILABLE == false with IO::Uring undefined and nothing crashing, while the unmodified/available path (the normal case for this sandbox) was rebuilt and tested end to end against this sandbox's real kernel: 1970 OK / 0 KO, matching every prior run in this repo, with the single Crash being the same pre-existing UDPSocket sandbox limitation unrelated to this change.