### PR TITLE
Give accept/multishot_accept a ready-to-use async socket via .sock

### DIFF
--- a/mrblib/io.rb
+++ b/mrblib/io.rb
@@ -23,6 +23,16 @@ class IO::Uring
     end
   end
 
+  class Socket
+    # IO::Uring.socket_for_fd (native) resolves TCPSocket/UNIXSocket/...
+    # under IO::Uring via getsockname -- it needs to run with self
+    # unambiguously IO::Uring itself for that, so this stays a thin
+    # delegator rather than a second native binding on this class.
+    def self.for_fd(fd)
+      IO::Uring.socket_for_fd(fd)
+    end
+  end
+
   module UringSocketBase
     def recv_nonblock
       raise NotImplementedError
@@ -60,12 +70,22 @@ class IO::Uring
       IO::Uring.default_io_uring.prep_listen(self, backlog, sqe_flags, &block)
     end
 
+    # IO::Uring::Socket.for_fd gives back the same async #send/#recv every
+    # other io_uring socket has. Written back into #operation.sock itself --
+    # #sock's post-completion value was just the bare accepted-fd Integer
+    # anyway, still available via #fileno regardless of this.
     def accept(flags = 0, sqe_flags = 0, &block)
-      IO::Uring.default_io_uring.prep_accept(self, flags, sqe_flags, &block)
+      IO::Uring.default_io_uring.prep_accept(self, flags, sqe_flags) do |operation|
+        operation.sock = IO::Uring.socket_for_fd(operation.res) unless operation.errno
+        block.call(operation) if block
+      end
     end
 
     def multishot_accept(flags = 0, sqe_flags = 0, &block)
-      IO::Uring.default_io_uring.prep_multishot_accept(self, flags, sqe_flags, &block)
+      IO::Uring.default_io_uring.prep_multishot_accept(self, flags, sqe_flags) do |operation|
+        operation.sock = IO::Uring.socket_for_fd(operation.res) unless operation.errno
+        block.call(operation) if block
+      end
     end
 
     def sysaccept
@@ -100,6 +120,12 @@ class IO::Uring
   end
 
   class File < ::File
+    # IO::Uring.file_for_fd (native) needs self unambiguously IO::Uring to
+    # build the right nested class -- see socket_for_fd's identical reasoning.
+    def self.for_fd(fd)
+      IO::Uring.file_for_fd(fd)
+    end
+
     def initialize(fd_or_path, mode = nil, perm = -1, resolve = nil, sqe_flags = 0, &block)
       if fd_or_path.kind_of? Integer
         super(fd_or_path, mode)

--- a/mrblib/operation.rb
+++ b/mrblib/operation.rb
@@ -9,8 +9,15 @@ if URING_AVAILABLE
 class IO
   class Uring
     class Operation
-      attr_reader :ring, :type, :sock, :splice_socks, :poll_mask, :file, :fileno, :directory, :operation, :res, :flags, :errno
+      attr_reader :ring, :type, :splice_socks, :poll_mask, :file, :fileno, :directory, :operation, :res, :flags, :errno
       attr_accessor :userdata
+
+      # A plain writer, not just attr_reader, so ServerSocketMethods#accept
+      # (io.rb) can upgrade #sock from the bare accepted-fd Integer the
+      # native layer sets it to into the properly classed, async-capable
+      # TCPSocket/UNIXSocket/... instance #to_io/.for_fd already knows how
+      # to build. The raw fd stays available via #fileno regardless.
+      attr_accessor :sock
 
       def buffer?
         flags & CQE_F_BUFFER != 0

--- a/src/mrb_io_uring.cpp
+++ b/src/mrb_io_uring.cpp
@@ -1657,8 +1657,12 @@ mrb_io_uring_file_for_fd(mrb_state *mrb, mrb_value self)
   mrb_value fd;
   mrb_get_args(mrb, "o", &fd);
 
-
-  mrb_value file_obj = mrb_obj_new(mrb, mrb_class_ptr(self), 1, &fd);
+  /* self is IO::Uring itself (this is registered there, same as
+   * socket_for_fd) -- construct File *nested under* self, not self
+   * directly, or calling this as IO::Uring.file_for_fd would try to
+   * build another IO::Uring ring instance instead of an IO::Uring::File. */
+  struct RClass *file_class = mrb_class_get_under_id(mrb, mrb_class_ptr(self), MRB_SYM(File));
+  mrb_value file_obj = mrb_obj_new(mrb, file_class, 1, &fd);
   (void)mrb_io_fileno(mrb, file_obj);
   ((struct mrb_io *)DATA_PTR(file_obj))->close_fd = 1;
   return file_obj;
@@ -2018,10 +2022,15 @@ mrb_mruby_io_uring_gem_init(mrb_state* mrb)
 
   struct RClass *io_uring_file_class = mrb_define_class_under_id(mrb, io_uring_class, MRB_SYM(File), mrb_class_get_id(mrb, MRB_SYM(File)));
   MRB_SET_INSTANCE_TT(io_uring_file_class, MRB_TT_CDATA);
-  mrb_define_module_function_id(mrb, io_uring_file_class, MRB_SYM(for_fd), mrb_io_uring_file_for_fd, MRB_ARGS_REQ(2));
   struct RClass *io_uring_socket_class = mrb_define_class_under_id(mrb, io_uring_class, MRB_SYM(Socket), mrb_class_get_id(mrb, MRB_SYM(Socket)));
   MRB_SET_INSTANCE_TT(io_uring_socket_class, MRB_TT_CDATA);
-  mrb_define_module_function_id(mrb, io_uring_socket_class, MRB_SYM(for_fd), mrb_io_uring_socket_for_fd, MRB_ARGS_REQ(2));
+  /* self here is unambiguously IO::Uring -- mrb_class_ptr(self) is exactly
+   * the namespace File/TCPSocket/UNIXSocket/... live under, no outer-class
+   * lookup needed. IO::Uring::File.for_fd/IO::Uring::Socket.for_fd (io.rb)
+   * are thin Ruby-level delegators to these, not second native bindings,
+   * so neither is ever called with self set to anything else. */
+  mrb_define_module_function_id(mrb, io_uring_class, MRB_SYM(file_for_fd), mrb_io_uring_file_for_fd, MRB_ARGS_REQ(1));
+  mrb_define_module_function_id(mrb, io_uring_class, MRB_SYM(socket_for_fd), mrb_io_uring_socket_for_fd, MRB_ARGS_REQ(1));
 }
 
 #else // MRB_IO_URING_BUILDABLE


### PR DESCRIPTION
## Summary
- `Operation#sock` used to hold the listener before an accept completed and a bare fd `Integer` after — callers had to manually wrap it (`to_io` + `extend`, or the still-broken `.for_fd`) to get async `#send`/`#recv`. `Operation#sock` is now a plain writer, and `ServerSocketMethods#accept`/`#multishot_accept` overwrite it with a properly classed (`TCPSocket`/`UNIXSocket`/...), async-capable socket via `IO::Uring.socket_for_fd` once the accept completes. `#fileno` keeps returning the raw fd regardless.
- Fixed the bugs in `.for_fd` surfaced while wiring this up: `IO::Uring::Socket.for_fd` and `IO::Uring::File.for_fd` were registered with `MRB_ARGS_REQ(2)` while their C bodies only ever read one argument, so every call failed arity checking no matter how many arguments were passed. `IO::Uring::Socket.for_fd` also resolved `TCPSocket`/`UNIXSocket`/... under itself (`IO::Uring::Socket`) instead of `IO::Uring`, where those classes actually live, and `IO::Uring::File.for_fd` built `mrb_class_ptr(self)` directly rather than `File` nested under `self` (only ever worked because it was never called with `self` set to anything but `IO::Uring::File`). Moved both native implementations to `IO::Uring` (`socket_for_fd`/`file_for_fd`, where `self` is unambiguously the right namespace), with `IO::Uring::Socket.for_fd`/`IO::Uring::File.for_fd` left as thin Ruby-level delegators to them.

## Test plan
- [x] Full `mrbtest` suite (mruby-tls + mruby-io_uring combined build): 2080/2083 OK, 0 KO, 1 pre-existing unrelated crash (`UDPSocket` sandbox limitation).
- [x] Manual: real `TCPServer`/`TCPSocket` accept over io_uring, `op.sock` comes back as `IO::Uring::TCPSocket` with working async `#recv`, real data received correctly.
- [x] Manual: `IO::Uring.file_for_fd`/`IO::Uring::File.for_fd` both verified working, including an actual async read through the wrapped file.
- [x] End-to-end: a `Tls::Server`/`Tls::Client` TLS handshake plus HTTP-style request/response round-trip, both sides driven entirely through this accepted socket over real io_uring completions.